### PR TITLE
Added -aoa argument to datical-upload

### DIFF
--- a/src/main/resources/datical/datical_upload.bat.ftl
+++ b/src/main/resources/datical/datical_upload.bat.ftl
@@ -18,7 +18,7 @@
     <#assign ziploc=deployed.container.zipLocation/>
 </#if>
 
-${ziploc} x ${deployed.file.path} -o${deployed.targetPath}
+${ziploc} x ${deployed.file.path} -aoa -o${deployed.targetPath}
 <#if !deployed.container.zipLocation?has_content>
     rmdir /s /q C:\Temp\7zip
 </#if>


### PR DESCRIPTION
Address issue where we set "override mode" for unzipping on Windows. This will address Issue #3 which prevented new upload when the last upload wasn't cleaned up. Using the "override mode", essentially passing "-aoa" argument to 7z.exe command, will force the overwrite.