### PR TITLE
Added functionality to remove passwords from clear text and support auditdb runtime credentials

### DIFF
--- a/src/main/resources/datical/datical_credentials.bat.ftl
+++ b/src/main/resources/datical/datical_credentials.bat.ftl
@@ -7,18 +7,10 @@
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+ 
 -->
-<#assign environment><#if deployed.container.envName?has_content>${deployed.container.envName}<#else>${deployed.envName}</#if></#assign>
 
-<#assign login>${deployed.container.home} <#if deployed.container.username?has_content>-un ${environment}:::${deployed.container.username} -pw ${environment}:::${deployed.container.password}</#if></#assign>
-
-<#assign login_simple>${deployed.container.home} </#assign>
-
-<#assign labels><#if deployed.labels?has_content>--labels="${deployed.labels}"</#if></#assign>
-
-<#assign reports><#if deployed.reportsLocation?has_content>--report="${deployed.reportsLocation}"</#if></#assign>
-
-<#assign pipeline><#if deployed.pipeline?has_content>--pipeline="${deployed.pipeline}"</#if></#assign>
-
-<#assign curl><#if deployed.curl_path?has_content>"${deployed.curl_path} --insecure --request POST https://${deployed.daticalweb_host}/service/reporting/qa/v1/audit-db/sync"</#if></#assign>
+<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>@set DDB_AUDIT_USER=${deployed.container.audit_username}</#if></#assign>
+<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>@set DDB_AUDIT_PASS=${deployed.container.audit_password}</#if></#assign>
+<#assign ddb_user><#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if></#assign>
+<#assign ddb_pass><#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if></#assign>

--- a/src/main/resources/datical/datical_credentials.sh.ftl
+++ b/src/main/resources/datical/datical_credentials.sh.ftl
@@ -7,18 +7,10 @@
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+ 
 -->
-<#assign environment><#if deployed.container.envName?has_content>${deployed.container.envName}<#else>${deployed.envName}</#if></#assign>
 
-<#assign login>${deployed.container.home} <#if deployed.container.username?has_content>-un ${environment}:::${deployed.container.username} -pw ${environment}:::${deployed.container.password}</#if></#assign>
-
-<#assign login_simple>${deployed.container.home} </#assign>
-
-<#assign labels><#if deployed.labels?has_content>--labels="${deployed.labels}"</#if></#assign>
-
-<#assign reports><#if deployed.reportsLocation?has_content>--report="${deployed.reportsLocation}"</#if></#assign>
-
-<#assign pipeline><#if deployed.pipeline?has_content>--pipeline="${deployed.pipeline}"</#if></#assign>
-
-<#assign curl><#if deployed.curl_path?has_content>"${deployed.curl_path} --insecure --request POST https://${deployed.daticalweb_host}/service/reporting/qa/v1/audit-db/sync"</#if></#assign>
+<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>export DDB_AUDIT_USER=${deployed.container.audit_username} > /dev/null</#if></#assign>
+<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>export DDB_AUDIT_PASS=${deployed.container.audit_password} > /dev/null</#if></#assign>
+<#assign ddb_user><#if deployed.container.username?has_content>export DDB_USER=${deployed.container.username} > /dev/null</#if></#assign>
+<#assign ddb_pass><#if deployed.container.password?has_content>export DDB_PASS=${deployed.container.password} > /dev/null</#if></#assign>

--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -10,4 +10,18 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.bat.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=%DDB_USER%
+echo DDB_PASS=%DDB_PASS%
+echo DDB_AUDIT_USER=%DDB_AUDIT_USER%
+echo DDB_AUDIT_PASS=%DDB_AUDIT_PASS%
+-->
+<#--
 ${login} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
+-->
+${login_simple} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -10,4 +10,18 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.sh.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=$DDB_USER
+echo DDB_PASS=$DDB_PASS
+echo DDB_AUDIT_USER=$DDB_AUDIT_USER
+echo DDB_AUDIT_PASS=$DDB_AUDIT_PASS
+-->
+<#--
 ${login} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
+-->
+${login_simple} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}

--- a/src/main/resources/datical/datical_forecast.bat.ftl
+++ b/src/main/resources/datical/datical_forecast.bat.ftl
@@ -10,4 +10,19 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
-${login} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports}
+<#include "/datical/datical_credentials.bat.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=%DDB_USER%
+echo DDB_PASS=%DDB_PASS%
+echo DDB_AUDIT_USER=%DDB_AUDIT_USER%
+echo DDB_AUDIT_PASS=%DDB_AUDIT_PASS%
+-->
+<#--
+${login} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
+-->
+cd ${deployed.targetPath}
+${login_simple} forecast ${environment} ${labels} ${reports} ${pipeline}

--- a/src/main/resources/datical/datical_forecast.sh.ftl
+++ b/src/main/resources/datical/datical_forecast.sh.ftl
@@ -10,4 +10,18 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
-${login} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports}
+<#include "/datical/datical_credentials.sh.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=$DDB_USER
+echo DDB_PASS=$DDB_PASS
+echo DDB_AUDIT_USER=$DDB_AUDIT_USER
+echo DDB_AUDIT_PASS=$DDB_AUDIT_PASS
+-->
+<#--
+${login} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
+-->
+${login_simple} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}

--- a/src/main/resources/datical/datical_generic.bat.ftl
+++ b/src/main/resources/datical/datical_generic.bat.ftl
@@ -1,0 +1,16 @@
+<#--
+
+    Copyright 2018 XEBIALABS
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+-->
+
+<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>set DDB_AUDIT_USER=${deployed.container.audit_username}</#if></#assign>
+<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>set DDB_AUDIT_PASS=${deployed.container.audit_password}</#if></#assign>
+<#assign ddb_user><#if deployed.container.username?has_content>set DDB_USER=${deployed.container.username}</#if></#assign>
+<#assign ddb_pass><#if deployed.container.password?has_content>set DDB_PASS=${deployed.container.password}</#if></#assign>

--- a/src/main/resources/datical/datical_generic.sh.ftl
+++ b/src/main/resources/datical/datical_generic.sh.ftl
@@ -1,0 +1,16 @@
+<#--
+
+    Copyright 2018 XEBIALABS
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+-->
+
+<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>export DDB_AUDIT_USER=${deployed.container.audit_username}</#if></#assign>
+<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>export DDB_AUDIT_PASS=${deployed.container.audit_password}</#if></#assign>
+<#assign ddb_user><#if deployed.container.username?has_content>export DDB_USER=${deployed.container.username}</#if></#assign>
+<#assign ddb_pass><#if deployed.container.password?has_content>export DDB_PASS=${deployed.container.password}</#if></#assign>

--- a/src/main/resources/datical/datical_status_detail.bat.ftl
+++ b/src/main/resources/datical/datical_status_detail.bat.ftl
@@ -10,4 +10,18 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.bat.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=%DDB_USER%
+echo DDB_PASS=%DDB_PASS%
+echo DDB_AUDIT_USER=%DDB_AUDIT_USER%
+echo DDB_AUDIT_PASS=%DDB_AUDIT_PASS%
+-->
+<#--
 ${login} -p ${deployed.targetPath} statusDetails ${environment}
+-->
+${login_simple} -p ${deployed.targetPath} statusDetails ${environment}

--- a/src/main/resources/datical/datical_status_detail.sh.ftl
+++ b/src/main/resources/datical/datical_status_detail.sh.ftl
@@ -10,4 +10,18 @@
 
 -->
 <#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.sh.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=$DDB_USER
+echo DDB_PASS=$DDB_PASS
+echo DDB_AUDIT_USER=$DDB_AUDIT_USER
+echo DDB_AUDIT_PASS=$DDB_AUDIT_PASS
+-->
+<#--
 ${login} -p ${deployed.targetPath} statusDetails ${environment}
+-->
+${login_simple} -p ${deployed.targetPath} statusDetails ${environment}

--- a/src/main/resources/datical/datical_undeploy.bat.ftl
+++ b/src/main/resources/datical/datical_undeploy.bat.ftl
@@ -9,11 +9,23 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
+
+<#include "/datical/datical_credentials.bat.ftl">
 <#include "/datical/datical_generic_undeploy.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
 <#if previousDeployed.changeids?size gt 0>
     <#list previousDeployed.changeids as changeid>
+	<#--
     ${login} -p ${previousDeployed.targetPath} rollback ${environment} changeid:id=${changeid}
+	-->
+    ${login_simple} -p ${previousDeployed.targetPath} rollback ${environment} changeid:id=${changeid}
     </#list>
 <#else>
+<#--
 ${login} -p ${previousDeployed.targetPath} rollback ${environment} lastdeploy
+-->
+${login_simple} -p ${previousDeployed.targetPath} rollback ${environment} lastdeploy
 </#if>

--- a/src/main/resources/datical/datical_undeploy.sh.ftl
+++ b/src/main/resources/datical/datical_undeploy.sh.ftl
@@ -9,11 +9,19 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
+
+<#include "/datical/datical_credentials.sh.ftl">
 <#include "/datical/datical_generic_undeploy.ftl">
 <#if previousDeployed.changeids?size gt 0>
     <#list previousDeployed.changeids as changeid>
+	<#--
+    ${login} -p ${previousDeployed.targetPath} rollback ${environment} changeid:id=${changeid}
+	-->
     ${login} -p ${previousDeployed.targetPath} rollback ${environment} changeid:id=${changeid}
     </#list>
 <#else>
+<#--
+${login} -p ${previousDeployed.targetPath} rollback ${environment} lastdeploy
+-->
 ${login} -p ${previousDeployed.targetPath} rollback ${environment} lastdeploy
 </#if>

--- a/src/main/resources/datical/datical_upload.bat.ftl
+++ b/src/main/resources/datical/datical_upload.bat.ftl
@@ -17,6 +17,7 @@
     <#assign ziploc=deployed.container.zipLocation/>
 </#if>
 
+rmdir /S /Q ${deployed.targetPath}
 ${ziploc} x ${deployed.file.path} -aoa -o${deployed.targetPath}
 <#if !deployed.container.zipLocation?has_content>
     rmdir /s /q C:\Temp\7zip

--- a/src/main/resources/datical/daticalweb_status_refresh.bat.ftl
+++ b/src/main/resources/datical/daticalweb_status_refresh.bat.ftl
@@ -7,10 +7,22 @@
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
--->
 
-<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>set DDB_AUDIT_USER=${deployed.container.audit_username}</#if></#assign>
-<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>set DDB_AUDIT_PASS=${deployed.container.audit_password}</#if></#assign>
-<#assign ddb_user><#if deployed.container.username?has_content>set DDB_USER=${deployed.container.username}</#if></#assign>
-<#assign ddb_pass><#if deployed.container.password?has_content>set DDB_PASS=${deployed.container.password}</#if></#assign>
+-->
+<#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.bat.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=%DDB_USER%
+echo DDB_PASS=%DDB_PASS%
+echo DDB_AUDIT_USER=%DDB_AUDIT_USER%
+echo DDB_AUDIT_PASS=%DDB_AUDIT_PASS%
+-->
+<#--
+${login} -p ${deployed.targetPath} status ${environment}
+-->
+${login_simple} -p ${deployed.targetPath} status ${environment}
+${curl}

--- a/src/main/resources/datical/daticalweb_status_refresh.sh.ftl
+++ b/src/main/resources/datical/daticalweb_status_refresh.sh.ftl
@@ -7,10 +7,28 @@
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
--->
 
-<#assign ddb_audit_user><#if deployed.container.audit_username?has_content>export DDB_AUDIT_USER=${deployed.container.audit_username}</#if></#assign>
-<#assign ddb_audit_pass><#if deployed.container.audit_password?has_content>export DDB_AUDIT_PASS=${deployed.container.audit_password}</#if></#assign>
-<#assign ddb_user><#if deployed.container.username?has_content>export DDB_USER=${deployed.container.username}</#if></#assign>
-<#assign ddb_pass><#if deployed.container.password?has_content>export DDB_PASS=${deployed.container.password}</#if></#assign>
+-->
+<#include "/datical/datical_generic.ftl">
+<#include "/datical/datical_credentials.sh.ftl">
+${ddb_audit_user}
+${ddb_audit_pass}
+${ddb_user}
+${ddb_pass}
+<#--
+echo DDB_USER=$DDB_USER
+echo DDB_PASS=$DDB_PASS
+echo DDB_AUDIT_USER=$DDB_AUDIT_USER
+echo DDB_AUDIT_PASS=$DDB_AUDIT_PASS
+-->
+<#--
+${login} -p ${deployed.targetPath} statusDetails ${environment}
+-->
+echo "Refeshing status with Datical Management Console ..."
+if [ "${curl}" != "" ] && [ "${daticalweb}" != "" ]; then
+	${login_simple} -p ${deployed.targetPath} status ${environment}
+	${curl} --insecure --request POST https://${daticalweb}/service/reporting/qa/v1/audit-db/sync
+else
+	echo "INFO: curl Command Path not set. Or Datical Web Hostname not specified."
+fi
+

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -25,11 +25,18 @@
                   description="Absolute Path to 7zip.exe (only applicable on Windows). If provided this one will be used, else the prepackaged one will be used."/>
         <property name="envName" label="Environment Name" required="false"
                   description="Environment name to be used for forecast and deploy (e.g. XE)"/>
-
         <property name="username" label="Username" required="false" category="Credentials"
                   description="Database username when the project has the 'Specify database credentials at operation run time' option set." />
         <property name="password" label="Password" required="false" category="Credentials" password="true"
                   description="Database password when the project has the 'Specify database credentials at operation run time' option set." />
+        <property name="audit_username" label="Audit Username" required="false" category="Credentials"
+                  description="Audit database username when the project has the 'Specify database credentials at operation run time' option set." />
+        <property name="audit_password" label="Audit Password" required="false" category="Credentials" password="true"
+                  description="Audit database password when the project has the 'Specify database credentials at operation run time' option set." />
+        <property name="curl_path" label="curl Command Path" required="false" 
+                  description="Fully qualified location of curl CLI command (e.g., C:\apps\Git\mingw64\bin\curl.exe). Required if Datical Web Hostname is specified." />
+        <property name="daticalweb_host" label="Datical Web Hostname" required="false" 
+                  description="The hostname for Datical Management Console (e.g., dmc.datical.net)." />
         <method name="check"
                 delegate="shellScript"
                 host="${thisCi.host}"

--- a/src/main/resources/xl-rules.xml
+++ b/src/main/resources/xl-rules.xml
@@ -78,7 +78,7 @@
         </steps>
     </rule>
 
-
+<!--
     <rule name="datical.DeployedProject.DESTROY" scope="deployed">
         <conditions>
             <type>datical.DeployedProject</type>
@@ -93,13 +93,11 @@
                     <deployed expression="true">previousDeployed</deployed>
                 </freemarker-context>
             </os-script>
-
             <os-script>
                 <description expression="true">"Undeploy datical %s" % previousDeployed.name</description>
                 <script>datical/datical_undeploy</script>
                 <order>42</order>
             </os-script>
-
             <os-script>
                 <description expression="true">"Remove project [%s] from server" % previousDeployed.name</description>
                 <script>datical/datical_remove</script>
@@ -111,6 +109,7 @@
             </os-script>
         </steps>
     </rule>
+-->
 
     <rule name="datical.DeployedProject.StatusDetail.DESTROY" scope="deployed">
         <conditions>
@@ -131,5 +130,20 @@
         </steps>
     </rule>
 
+	<rule name="datical.DeployedProject.StatusDetail.After.CREATE" scope="deployed">
+        <conditions>
+            <type>datical.DeployedProject</type>
+            <operation>CREATE</operation>
+            <operation>MODIFY</operation>
+        </conditions>
+        <steps>
+            <os-script>
+                <description expression="true">"Refresh Datical Monitoring Console"</description>
+                <script>datical/daticalweb_status_refresh</script>
+                <order>63</order>
+                <upload-artifacts>false</upload-artifacts>
+            </os-script>
+        </steps>
+    </rule>
 
 </rules>


### PR DESCRIPTION
Modified a number of files in this pull request. These mods tackle two main use cases:
1. Remove database runtime credentials from showing up in clear text - Issue #6 
2. Creates new properties so that user can also specify credentials for AUDITDB - Issue #7 

Regarding #1...
For Windows, sensitive output is removed using "@". 
For Linux, sensitive output is removed using "/dev/null" 

Here is a list of new files added
        src/main/resources/datical/datical_credentials.bat.ftl
        src/main/resources/datical/datical_credentials.sh.ftl
	src/main/resources/datical/daticalweb_status_refresh.bat.ftl
	src/main/resources/datical/daticalweb_status_refresh.sh.ftl
		
Here is a list of existing files that were modified:
        modified:   src/main/resources/datical/datical_deploy.bat.ftl
        modified:   src/main/resources/datical/datical_deploy.sh.ftl
        modified:   src/main/resources/datical/datical_forecast.bat.ftl
        modified:   src/main/resources/datical/datical_forecast.sh.ftl
        modified:   src/main/resources/datical/datical_generic.ftl
        modified:   src/main/resources/datical/datical_status_detail.bat.ftl
        modified:   src/main/resources/datical/datical_status_detail.sh.ftl
        modified:   src/main/resources/datical/datical_upload.bat.ftl
        modified:   src/main/resources/datical/datical_undeploy.bat.ftl
        modified:   src/main/resources/datical/datical_undeploy.sh.ftl
        modified:   src/main/resources/synthetic.xml
