### PR TITLE
Added support for immutableProject argument

### DIFF
--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -13,7 +13,7 @@
 <#include "/datical/datical_credentials.sh.ftl">
 cd ${deployed.targetPath}
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_forecast.bat.ftl
+++ b/src/main/resources/datical/datical_forecast.bat.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}  --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_forecast.sh.ftl
+++ b/src/main/resources/datical/datical_forecast.sh.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName}  forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>


### PR DESCRIPTION
Latest release of Datical requires the use of "immutableProject=<true|false>" argument for forecast and deploy operations. This pull request implements this new requirement.