### PR TITLE
Disabled undeploy and added genRollbackSQL instead

### DIFF
--- a/.travel.yml
+++ b/.travel.yml
@@ -1,0 +1,1 @@
+jdk: openjdk8

--- a/src/main/resources/datical/check_hammer.bat.ftl
+++ b/src/main/resources/datical/check_hammer.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/check_hammer.sh.ftl
+++ b/src/main/resources/datical/check_hammer.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_credentials.bat.ftl
+++ b/src/main/resources/datical/datical_credentials.bat.ftl
@@ -13,13 +13,19 @@ echo Isdaticalservice=${isdaticalservice}
 <#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
 <#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>
 <#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if>
--->
+
 <#if !(deployed.container.daticalServiceHost?has_content)>
 	<#if deployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${deployed.container.auditUsername}</#if>
 	<#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
 	<#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>
 	<#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if>
 </#if>
+-->
+
+<#if deployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${deployed.container.auditUsername}</#if>
+<#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
+<#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>
+<#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if>
 
 <#if deployed.container.daticalServiceUserName?has_content>@set DATICAL_USERNAME=${deployed.container.daticalServiceUserName}</#if>
 <#if deployed.container.daticalServicePassword?has_content>@set DATICAL_PASSWORD=${deployed.container.daticalServicePassword}</#if>

--- a/src/main/resources/datical/datical_credentials.bat.ftl
+++ b/src/main/resources/datical/datical_credentials.bat.ftl
@@ -1,27 +1,14 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
-echo Isdaticalservice=${isdaticalservice}
-<#if deployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${deployed.container.auditUsername}</#if>
-<#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
-<#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>
-<#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if>
 
-<#if !(deployed.container.daticalServiceHost?has_content)>
-	<#if deployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${deployed.container.auditUsername}</#if>
-	<#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
-	<#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>
-	<#if deployed.container.password?has_content>@set DDB_PASS=${deployed.container.password}</#if>
-</#if>
 -->
-
 <#if deployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${deployed.container.auditUsername}</#if>
 <#if deployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${deployed.container.auditPassword}</#if>
 <#if deployed.container.username?has_content>@set DDB_USER=${deployed.container.username}</#if>

--- a/src/main/resources/datical/datical_credentials.sh.ftl
+++ b/src/main/resources/datical/datical_credentials.sh.ftl
@@ -1,15 +1,14 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
--->
 
+-->
 <#if !(deployed.container.daticalServiceHost?has_content)>
 	<#if deployed.container.auditUsername?has_content>export DDB_AUDIT_USER=${deployed.container.auditUsername} > /dev/null</#if>
 	<#if deployed.container.auditPassword?has_content>export DDB_AUDIT_PASS=${deployed.container.auditPassword} > /dev/null</#if>

--- a/src/main/resources/datical/datical_credentials_undeploy.bat.ftl
+++ b/src/main/resources/datical/datical_credentials_undeploy.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -9,7 +9,6 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
-
 <#if previousDeployed.container.auditUsername?has_content>@set DDB_AUDIT_USER=${previousDeployed.container.auditUsername}</#if>
 <#if previousDeployed.container.auditPassword?has_content>@set DDB_AUDIT_PASS=${previousDeployed.container.auditPassword}</#if>
 <#if previousDeployed.container.username?has_content>@set DDB_USER=${previousDeployed.container.username}</#if>

--- a/src/main/resources/datical/datical_credentials_undeploy.sh.ftl
+++ b/src/main/resources/datical/datical_credentials_undeploy.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -9,7 +9,6 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
-
 <#if previousDeployed.container.auditUsername?has_content>export DDB_AUDIT_USER=${previousDeployed.container.auditUsername}</#if>
 <#if previousDeployed.container.auditPassword?has_content>export DDB_AUDIT_PASS=${previousDeployed.container.auditPassword}</#if>
 <#if previousDeployed.container.username?has_content>export DDB_USER=${previousDeployed.container.username}</#if>

--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -14,7 +14,10 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true
+	<#--
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} ${daticalServiceImmutable}
+	-->
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -19,5 +19,5 @@ cd ${deployed.targetPath}
 	-->
 	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
-	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
+	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline} ${genRollbackSQL}
 </#if>

--- a/src/main/resources/datical/datical_deploy.bat.ftl
+++ b/src/main/resources/datical/datical_deploy.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -13,7 +13,10 @@
 <#include "/datical/datical_credentials.sh.ftl">
 cd ${deployed.targetPath}
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
+	<#--
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} ${daticalServiceImmutable}
+	-->
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -18,5 +18,5 @@ cd ${deployed.targetPath}
 	-->
 	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
-	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
+	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline} ${genRollbackSQL}
 </#if>

--- a/src/main/resources/datical/datical_deploy.sh.ftl
+++ b/src/main/resources/datical/datical_deploy.sh.ftl
@@ -13,7 +13,7 @@
 <#include "/datical/datical_credentials.sh.ftl">
 cd ${deployed.targetPath}
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} deploy ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} deploy ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_forecast.bat.ftl
+++ b/src/main/resources/datical/datical_forecast.bat.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}  --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_forecast.bat.ftl
+++ b/src/main/resources/datical/datical_forecast.bat.ftl
@@ -14,9 +14,10 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}  --immutableProject=true 
+	set
+	<#--${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}  ${daticalServiceImmutable}
+	-->
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>
-
--->

--- a/src/main/resources/datical/datical_forecast.bat.ftl
+++ b/src/main/resources/datical/datical_forecast.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_forecast.sh.ftl
+++ b/src/main/resources/datical/datical_forecast.sh.ftl
@@ -14,7 +14,10 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName}  forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
+	<#--
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName}  forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} ${daticalServiceImmutable} 
+	-->
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName}  forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_forecast.sh.ftl
+++ b/src/main/resources/datical/datical_forecast.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_forecast.sh.ftl
+++ b/src/main/resources/datical/datical_forecast.sh.ftl
@@ -14,7 +14,7 @@
 cd ${deployed.targetPath}
 
 <#if deployed.container.daticalServiceHost?has_content>
-	${hammer} ${daticalServiceHost} ${daticalServiceUserName} forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports}
+	${hammer} ${daticalServiceHost} ${daticalServiceUserName}  forecast ${pipeline} ${environment} ${daticalServiceProject} ${labels} ${reports} --immutableProject=true 
 <#else>
 	${hammer} -p ${deployed.targetPath} forecast ${environment} ${labels} ${reports} ${pipeline}
 </#if>

--- a/src/main/resources/datical/datical_generic.ftl
+++ b/src/main/resources/datical/datical_generic.ftl
@@ -26,3 +26,5 @@
 <#assign labels><#if deployed.labels?has_content>--labels="${deployed.labels}"</#if></#assign>
 <#assign reports><#if deployed.reportsLocation?has_content>--report="${deployed.reportsLocation}"</#if></#assign>
 <#assign pipeline><#if deployed.pipeline?has_content>--pipeline="${deployed.pipeline}"</#if></#assign>
+
+<#assign daticalServiceImmutable>--immutableProject=true</#assign>

--- a/src/main/resources/datical/datical_generic.ftl
+++ b/src/main/resources/datical/datical_generic.ftl
@@ -22,5 +22,6 @@
 <#assign labels><#if deployed.labels?has_content>--labels="${deployed.labels}"</#if></#assign>
 <#assign reports><#if deployed.reportsLocation?has_content>--report="${deployed.reportsLocation}"</#if></#assign>
 <#assign pipeline><#if deployed.pipeline?has_content>--pipeline="${deployed.pipeline}"</#if></#assign>
+<#assign genRollbackSQL><#if deployed.genRollbackSQL==true>--genRollbackSQL</#if></#assign>
 
 <#assign daticalServiceImmutable>--immutableProject=true</#assign>

--- a/src/main/resources/datical/datical_generic.ftl
+++ b/src/main/resources/datical/datical_generic.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -8,11 +8,7 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-<#assign hammerweb><#if isdaticalservice=="true">${deployed.container.home} --daticalServer=${deployed.container.daticalservice_server} --daticalUsername=${deployed.container.daticalServiceUserName}</#if></#assign>
-<#assign isdaticalservice>${(deployed.container.daticalServiceHost)?has_content}</#assign>
-<#assign isdaticalservice><#if deployed.container.daticalServiceHost?has_content>"true"<#else>"false"</#if></#assign>
 -->
-
 <#assign environment><#if deployed.container.envName?has_content>${deployed.container.envName}<#else>${deployed.envName}</#if></#assign>
 
 <#assign hammer>${deployed.container.home}</#assign>

--- a/src/main/resources/datical/datical_generic_undeploy.ftl
+++ b/src/main/resources/datical/datical_generic_undeploy.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_remove.bat.ftl
+++ b/src/main/resources/datical/datical_remove.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_remove.sh.ftl
+++ b/src/main/resources/datical/datical_remove.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_status.bat.ftl
+++ b/src/main/resources/datical/datical_status.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_status.sh.ftl
+++ b/src/main/resources/datical/datical_status.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_undeploy.bat.ftl
+++ b/src/main/resources/datical/datical_undeploy.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -9,7 +9,6 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
-
 <#include "/datical/datical_generic_undeploy.ftl">
 <#include "/datical/datical_credentials_undeploy.bat.ftl">
 <#if previousDeployed.changeids?size gt 0>

--- a/src/main/resources/datical/datical_undeploy.sh.ftl
+++ b/src/main/resources/datical/datical_undeploy.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -9,7 +9,6 @@
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -->
-
 <#include "/datical/datical_generic_undeploy.ftl">
 <#include "/datical/datical_credentials_undeploy.sh.ftl">
 <#if previousDeployed.changeids?size gt 0>

--- a/src/main/resources/datical/datical_upload.bat.ftl
+++ b/src/main/resources/datical/datical_upload.bat.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/datical/datical_upload.sh.ftl
+++ b/src/main/resources/datical/datical_upload.sh.ftl
@@ -1,6 +1,6 @@
 <#--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/planning/create_plan.py
+++ b/src/main/resources/planning/create_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 XEBIALABS
+# Copyright 2019 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/planning/destroy_plan.py
+++ b/src/main/resources/planning/destroy_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 XEBIALABS
+# Copyright 2019 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #
@@ -18,12 +18,12 @@ def destroyPlan( context ):
 			freemarker_context = {'deployed': previousDeployed}
 		))
 
-		context.addStep(steps.os_script(
-			description = "Undeploy datical [%s]" % previousDeployed.name,
-			order = 43,
-			script = "datical/datical_undeploy",
-			freemarker_context={'deployed': previousDeployed}
-		))
+		# context.addStep(steps.os_script(
+			# description = "Undeploy datical [%s]" % previousDeployed.name,
+			# order = 43,
+			# script = "datical/datical_undeploy",
+			# freemarker_context={'deployed': previousDeployed}
+		# ))
 
 		context.addStep(steps.os_script(
 			description = "Remove project [%s] from server" % previousDeployed.name,

--- a/src/main/resources/planning/modify_plan.py
+++ b/src/main/resources/planning/modify_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 XEBIALABS
+# Copyright 2019 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/planning/modify_plan.py
+++ b/src/main/resources/planning/modify_plan.py
@@ -15,7 +15,7 @@ def modifyPlan( context ):
 	regex = r"(\d*)$"
 	versionDeployed = re.search(regex, deployedApplication.version.name).group(0)
 	versionPreviousDeployed = re.search(regex, previousDeployedApplication.version.name).group(0)
-	isRollback = int(versionDeployed) < int(versionPreviousDeployed)
+#	isRollback = int(versionDeployed) < int(versionPreviousDeployed)
 
 	if delta.operation == "MODIFY":
 
@@ -34,26 +34,33 @@ def modifyPlan( context ):
 
 		# Detect new version or older version
 		# Perform rollback if deploying older version
-		if isRollback :
+		# if isRollback :
 
-			context.addStep(steps.os_script(
-				description = "Rollback [%s to %s]" % (previousDeployed.name, versionDeployed),
-				order = 63,
-				script = "datical/datical_undeploy",
-				freemarker_context={'deployed': previousDeployed}
-			))
+			# context.addStep(steps.os_script(
+				# description = "Rollback [%s to %s]" % (previousDeployed.name, versionDeployed),
+				# order = 63,
+				# script = "datical/datical_undeploy",
+				# freemarker_context={'deployed': previousDeployed}
+			# ))
 
 		# End if versionDeployed > versionPreviousDeployed
-		else :
+		# else :
 
-			context.addStep(steps.os_script(
-				description = "Deploy [%s version %s]" % (deployed.name, versionDeployed),
-				order = 63,
-				script = "datical/datical_deploy"
-			))
-
+			# context.addStep(steps.os_script(
+				# description = "Deploy [%s version %s]" % (deployed.name, versionDeployed),
+				# order = 63,
+				# script = "datical/datical_deploy"
+			# ))
+			
 		# End else
-
+		
+		# Comment this section 
+		context.addStep(steps.os_script(
+			description = "Deploy [%s version %s]" % (deployed.name, versionDeployed),
+			order = 63,
+			script = "datical/datical_deploy"
+		))
+		
 		# Optional "Status" and "Forecast" steps:
 		if deployed.runStatus :
 			context.addStep(steps.os_script(
@@ -63,7 +70,8 @@ def modifyPlan( context ):
 			))
 		# End deployed.runStatus
 
-		if (deployed.runForecast and not isRollback):
+#		if (deployed.runForecast and not isRollback):
+		if (deployed.runForecast):
 			context.addStep(steps.os_script(
 				description = "Forecast for datical project [%s]" % deployed.name,
 				order = 62,

--- a/src/main/resources/plugin-version.properties
+++ b/src/main/resources/plugin-version.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 XEBIALABS
+# Copyright 2019 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -80,6 +80,9 @@
         <property name="pipeline" label="Pipeline"
                   description="When set, this is the pipeline which will be associated with the deployment for auditing purposes."
                   required="false" />
+        <property name="genRollbackSQL" label="Generate Rollback SQL"
+                  description="When set, a rollback SQL script will be generated in the reports directory."
+                  kind="boolean" default="false" required="false" />
 
     </type>
 

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/main/resources/xl-rules.xml
+++ b/src/main/resources/xl-rules.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/test/resources/docker/initialize/cis/configuration-items.xml
+++ b/src/test/resources/docker/initialize/cis/configuration-items.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 XEBIALABS
+    Copyright 2019 XEBIALABS
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/test/resources/docker/initialize/xld_initialize.py
+++ b/src/test/resources/docker/initialize/xld_initialize.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 XEBIALABS
+# Copyright 2019 XEBIALABS
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 #


### PR DESCRIPTION
Customers were having issues with the undeploy capability due to the nature of databases (Datical overlays changes instead of doing install so it becomes difficult to undeploy/rollback changes to the previous state). Instead, the desire was to generate a rollback SQL script and apply it manually if changes are unable to be deployed.